### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openvpn docker-compose setup
 [![Docker Stars](https://img.shields.io/docker/stars/enoniccloud/openvpn.svg)](https://hub.docker.com/r/enoniccloud/openvpn/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/enoniccloud/openvpn.svg)](https://hub.docker.com/r/enoniccloud/openvpn/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/enoniccloud/openvpn.svg)](https://hub.docker.com/r/enoniccloud/openvpn/) [![](https://images.microbadger.com/badges/image/enoniccloud/openvpn.svg)](https://microbadger.com/images/enoniccloud/openvpn "Get your own image badge on microbadger.com")
 
 
 This is a docker image forked out of the [kylemanna/docker-openvpn](https://github.com/kylemanna/docker-openvpn) repo to be used in Enonic Cloud. Feel free to use it on your own server too as this is made to be compatible with a generic docker-compose setup too.
@@ -45,3 +45,4 @@ storage:
 
 ## List client certificates
 - Run the following commands to list certificates: `docker-compose run --rm openvpn ovpn_listclients`
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [enoniccloud/openvpn](https://hub.docker.com/r/enoniccloud/openvpn/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/enoniccloud/openvpn).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/enoniccloud/openvpn.svg)](https://microbadger.com/images/enoniccloud/openvpn)
